### PR TITLE
fix: Corrected the edit product redirect logic in products.php

### DIFF
--- a/admin/products.php
+++ b/admin/products.php
@@ -379,7 +379,7 @@ if (isset($_GET['logout'])) {
 
                                         <td>
                                             <div class="btn-group btn-group-sm">
-                                                <button class="btn btn-outline-primary" title="Edit" onclick="editProduct('IPH15P001')">
+                                                <button class="btn btn-outline-primary" title="Edit" onclick="editProduct(<?php echo $product['product_id']; ?>)">
                                                     <i class="fas fa-edit"></i>
                                                 </button>
                                                 <button class="btn btn-outline-danger" title="Delete" onclick="deleteProduct('IPH15P001')">
@@ -446,10 +446,9 @@ if (isset($_GET['logout'])) {
         }
 
         // Edit product function
-        function editProduct(sku) {
-            // In a real application, this would redirect to an edit page or open a modal
-            console.log('Editing product with SKU:', sku);
-            alert(`Edit product ${sku} (This would open an edit form in a real application)`);
+        function editProduct(productID) {
+            // Redirect to edit product page with the product ID as a parameter
+            window.location.href = 'edit_product.php?id=' + productId;
         }
 
         // Delete product function


### PR DESCRIPTION
Fixed the edit button functionality in the products table to properly redirect to the edit product page with the correct product ID. Previously, the edit button was using a hardcoded value ('IPH15P001'), which has been replaced with the dynamic product ID from the database. This ensures each product's edit button correctly passes its unique ID to the edit_product.php page via URL parameter (?id=productId).