### PR TITLE
fix: Corrected related product links on single product page - Minor UI improvements

### DIFF
--- a/assets/css/pages/shop.css
+++ b/assets/css/pages/shop.css
@@ -361,8 +361,11 @@ body.shop-page {
     color: var(--text-dark);
     margin-bottom: 6px;
     line-height: 1.3;
+
     display: -webkit-box;
-    -webkit-line-clamp: 2;      /* Limit to 2 lines */
+    -webkit-line-clamp: 1;      /* Limit to 2 lines */
+    -webkit-box-orient: vertical; /* Required for -webkit-line-clamp */
+    text-overflow: ellipsis;     /* Add ellipsis (...) for hidden text */
     -webkit-box-orient: vertical;
     overflow: hidden;           /* Hide overflow text */
 }

--- a/layouts/footer.html
+++ b/layouts/footer.html
@@ -79,7 +79,7 @@
                         
                         <h6 style="color: #FFD700; margin-bottom: 15px;"><i class="fas fa-envelope"></i> Get In Touch</h6>
                         <p><i class="fas fa-map-marker-alt"></i> Cape Town, South Africa</p>
-                        <p><i class="fas fa-phone"></i> +27 (0) 21 XXX XXXX</p>
+                        <p><i class="fas fa-phone"></i> +27 (0) 64 227 5583</p>
                         <p><i class="fas fa-envelope"></i> info@mmsports.co.za</p>
                         <p><i class="fas fa-clock"></i> Mon-Fri: 8AM-6PM</p>
                     </div>

--- a/singleProduct.php
+++ b/singleProduct.php
@@ -143,7 +143,7 @@ else {
 
 
       <!--Related Products-->
-    <section id="related-products" class="my-5 pb-5">
+    <section id="related-products" class="my-5 pb-3">
         <div class="container text-center mt-5 py-5">
           <h3>Related Products</h3>
           <hr class="mx-auto">
@@ -167,7 +167,7 @@ else {
                 <h5 class="p-name"><?php echo $row['product_name']; ?></h5>
                 <h4 class="p-price"><?php echo $row['price']; ?></h4>
                 <p>Simply the best on the market</p>
-                <button class="buy-btn">Buy Now</button>
+                <a href="singleProduct.php?product_id=<?php echo $row['product_id']; ?>" class="buy-btn">Buy Now</a>
               </div>
           <?php } ?>
         </div>


### PR DESCRIPTION
This PR fixes a bug where clicking on a related product on the single product page would not redirect to the correct item's detail page. The anchor tags were updated to dynamically link each related product by its ID or slug. Now, users can navigate between related products properly.